### PR TITLE
Move proxy file location

### DIFF
--- a/elasticpress-proxy.php
+++ b/elasticpress-proxy.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       ElasticPress Proxy
  * Description:       A custom PHP Proxy to handle Instant Results requests.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            10up | ElasticPress.io
  * Author URI:        https://elasticpress.io
  * Text Domain:       elasticpress-proxy

--- a/elasticpress-proxy.php
+++ b/elasticpress-proxy.php
@@ -52,11 +52,9 @@ function save_template( $search_template ) {
 
 	$file_content = implode( "\n", $file_content );
 
-	$uploads_dir = wp_upload_dir();
-
 	$wp_filesystem->put_contents(
-		trailingslashit( $uploads_dir['basedir'] ) . 'ep-custom-proxy-credentials.php',
-		$file_content
+        trailingslashit( WP_CONTENT_DIR ) . 'ep-custom-proxy.php',
+        $file_content
 	);
 }
 add_action( 'ep_instant_results_template_saved', __NAMESPACE__ . '\save_template' );

--- a/proxy.php
+++ b/proxy.php
@@ -78,7 +78,7 @@ class EP_PHP_Proxy {
 		 *
 		 * It contains the template query, credentials, and the endpoint URL.
 		 */
-		require '../../uploads/ep-custom-proxy-credentials.php';
+		require '../../ep-custom-proxy.php';
 
 		$this->query          = $query_template;
 		$this->post_index_url = $post_index_url;


### PR DESCRIPTION
The original example plugin did not accommodate for S3 Uploads.

Moving the proxy file location to the content directory.